### PR TITLE
SCDB hashMerkleRoot commits & network updates

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -34,6 +34,7 @@ BITCOIN_TESTS =\
   test/bip32_tests.cpp \
   test/blockencodings_tests.cpp \
   test/bloom_tests.cpp \
+  test/bmm_tests.cpp \
   test/bswap_tests.cpp \
   test/checkqueue_tests.cpp \
   test/coins_tests.cpp \

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -18,7 +18,6 @@ class UniValue;
 // core_read.cpp
 CScript ParseScript(const std::string& s);
 std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode = false);
-std::string StateScriptToAsmStr(const CScript& script);
 bool DecodeHexTx(CMutableTransaction& tx, const std::string& strHexTx, bool fTryNoWitness = false);
 bool DecodeHexBlk(CBlock&, const std::string& strHexBlk);
 uint256 ParseHashUV(const UniValue& v, const std::string& strName);

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -114,25 +114,6 @@ std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDeco
     return str;
 }
 
-std::string StateScriptToAsmStr(const CScript& script)
-{
-    std::string str;
-    opcodetype opcode;
-    std::vector<unsigned char> vch;
-    CScript::const_iterator pc = script.begin();
-    while (pc < script.end()) {
-        if (!str.empty()) {
-            str += " ";
-        }
-        if (!script.GetOp(pc, opcode, vch)) {
-            str += "[error]";
-            return str;
-        }
-        str += GetSCOPName((scopcodetype) opcode);
-    }
-    return str;
-}
-
 std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags)
 {
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION | serializeFlags);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -193,12 +193,12 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     coinbaseTx.vout.resize(1);
     coinbaseTx.vout[0].scriptPubKey = scriptPubKeyIn;
 
-    // Track sidechain state tx fees
+    // Track sidechain tx fees
     CAmount nSideFees = 0;
 
     // Add WT^(s) which have been validated
     for (const Sidechain& s : ValidSidechains) {
-        CTransaction wtx = CreateSidechainWTJoinTx(s.nSidechain);
+        CTransaction wtx = CreateWTPrimePayout(s.nSidechain);
         if (wtx.vout.size() && wtx.vin.size())
             pblock->vtx.push_back(MakeTransactionRef(std::move(wtx)));
     }
@@ -334,7 +334,7 @@ int BlockAssembler::UpdatePackagesForAdded(const CTxMemPool::setEntries& already
     return nDescendantsUpdated;
 }
 
-CTransaction BlockAssembler::CreateSidechainWTJoinTx(uint8_t nSidechain)
+CTransaction BlockAssembler::CreateWTPrimePayout(uint8_t nSidechain)
 {
     // The WT^ that will be created
     CMutableTransaction mtx;
@@ -353,10 +353,10 @@ CTransaction BlockAssembler::CreateSidechainWTJoinTx(uint8_t nSidechain)
     // Select the highest scoring B-WT^ for sidechain this tau
     uint256 hashBest = uint256();
     uint16_t scoreBest = 0;
-    std::vector<SidechainWTJoinState> vState = scdb.GetState(nSidechain);
-    for (const SidechainWTJoinState& state : vState) {
+    std::vector<SidechainWTPrimeState> vState = scdb.GetState(nSidechain);
+    for (const SidechainWTPrimeState& state : vState) {
         if (state.nWorkScore > scoreBest || scoreBest == 0) {
-            hashBest = state.wtxid;
+            hashBest = state.hashWTPrime;
             scoreBest = state.nWorkScore;
         }
     }
@@ -368,11 +368,13 @@ CTransaction BlockAssembler::CreateSidechainWTJoinTx(uint8_t nSidechain)
         return mtx;
 
     // Copy outputs from B-WT^
-    std::vector<CTransaction> vWTJoin = scdb.GetWTJoinCache();
-    for (const CTransaction& tx : vWTJoin) {
-        if (tx.GetHash() == hashBest)
+    std::vector<CTransaction> vWTPrime = scdb.GetWTPrimeCache();
+    for (const CTransaction& tx : vWTPrime) {
+        if (tx.GetHash() == hashBest) {
             for (const CTxOut& out : tx.vout)
                 mtx.vout.push_back(out);
+            break;
+        }
     }
     if (!mtx.vout.size())
         return mtx;
@@ -447,10 +449,7 @@ CTransaction BlockAssembler::CreateSidechainWTJoinTx(uint8_t nSidechain)
 
 CTxOut BlockAssembler::CreateSCDBHashMerkleRootCommit()
 {
-    // TODO this call will be replaced when the MT based update PR Is merged.
-    // For now just getting the old style SCDB hash and putting it into the
-    // commitment.
-    const uint256& hashMerkleRoot = scdb.GetSCDBHash();
+    const uint256& hashMerkleRoot = scdb.GetHash();
     CScript script = GenerateSCDBHashMerkleRootCommitment(hashMerkleRoot);
     return CTxOut(CENT, script);
 }

--- a/src/miner.h
+++ b/src/miner.h
@@ -207,7 +207,7 @@ private:
 
     // SidechainDB
     /** Returns a WT^ payout transaction for nSidechain if there is one */
-    CTransaction CreateSidechainWTJoinTx(uint8_t nSidechain);
+    CTransaction CreateWTPrimePayout(uint8_t nSidechain);
     /** Returns an output with a commitment to the SCDB hashMerkleRoot */
     CTxOut CreateSCDBHashMerkleRootCommit();
 };

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -125,7 +125,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "createbribe", 0, "amount" },
     { "createbribe", 1, "height" },
     { "listsidechaindeposits", 0, "nsidechain" },
-    { "receivesidechainwtjoin", 0, "nsidechain" },
+    { "receivesidechainwtprime", 0, "nsidechain" },
+    { "receivesidechainwtprimeupdate", 0, "height" },
+    { "receivesidechainwtprimeupdate", 1, "update" },
     { "refundbribe", 0, "amount" },
     { "refundbribe", 2, "pos" },
     // Echo with conversion (For testing only)

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -151,23 +151,6 @@ const char* GetOpName(opcodetype opcode)
     }
 }
 
-const char* GetSCOPName(scopcodetype sopcode)
-{
-    switch (sopcode)
-    {
-    case SCOP_VERSION           : return "VERSION";
-    case SCOP_REJECT            : return "REJECT";
-    case SCOP_VERIFY            : return "VERIFY";
-    case SCOP_IGNORE            : return "IGNORE";
-    case SCOP_VERSION_DELIM     : return "VERSION_DELIM";
-    case SCOP_WT_DELIM          : return "WT_DELIM";
-    case SCOP_SC_DELIM          : return "SC_DELIM";
-
-    default:
-        return "OP_UNKNOWN";
-    }
-}
-
 unsigned int CScript::GetSigOpCount(bool fAccurate) const
 {
     unsigned int n = 0;

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -190,24 +190,6 @@ enum opcodetype
 
 const char* GetOpName(opcodetype opcode);
 
-/* Sidechain state script opcodes (not really opcodes) */
-enum scopcodetype {
-    // State script version
-    SCOP_VERSION = 0x00,
-
-    // Vote types
-    SCOP_REJECT = 0x51,
-    SCOP_VERIFY = 0x52,
-    SCOP_IGNORE = 0x53,
-
-    // Delimeters
-    SCOP_VERSION_DELIM = 0x54,
-    SCOP_WT_DELIM = 0x55,
-    SCOP_SC_DELIM = 0x56,
-};
-
-const char* GetSCOPName(scopcodetype sopcode);
-
 class scriptnum_error : public std::runtime_error
 {
 public:
@@ -487,24 +469,6 @@ public:
         // I'm not sure if this should push the script or concatenate scripts.
         // If there's ever a use for pushing a script onto a script, delete this member fn
         assert(!"Warning: Pushing a CScript onto a CScript with << is probably not intended, use + to concatenate!");
-        return *this;
-    }
-
-    CScript& operator<<(scopcodetype scopcode)
-    {
-        switch (scopcode) {
-        case SCOP_IGNORE:
-        case SCOP_REJECT:
-        case SCOP_SC_DELIM:
-        case SCOP_VERIFY:
-        case SCOP_VERSION:
-        case SCOP_VERSION_DELIM:
-        case SCOP_WT_DELIM:
-            break;
-        default:
-            throw std::runtime_error("CScript::operator<<(): invalid scopcode");
-        }
-        insert(end(), (unsigned char)scopcode);
         return *this;
     }
 

--- a/src/sidechain.h
+++ b/src/sidechain.h
@@ -36,12 +36,12 @@ struct Sidechain {
     uint16_t nVerificationPeriod;
     uint16_t nMinWorkScore;
 
-    std::string ToString() const;
     std::string GetSidechainName() const;
     uint16_t GetTau() const;
     // Return height of the end of previous / beginning of current tau
     int GetLastTauHeight(int nHeight) const;
     bool operator==(const Sidechain& a) const;
+    std::string ToString() const;
 };
 
 struct SidechainDeposit {
@@ -49,20 +49,32 @@ struct SidechainDeposit {
     CKeyID keyID;
     CMutableTransaction tx;
 
-    std::string ToString() const;
     bool operator==(const SidechainDeposit& a) const;
+    std::string ToString() const;
 };
 
-struct SidechainWTJoinState {
+struct SidechainUpdateMSG {
+    uint8_t nSidechain;
+    uint256 hashWTPrime;
+    uint16_t nWorkScore;
+    int nHeight;
+};
+
+struct SidechainUpdatePackage {
+    int nHeight;
+    std::vector<SidechainUpdateMSG> vUpdate;
+};
+
+struct SidechainWTPrimeState {
     uint8_t nSidechain;
     uint16_t nBlocksLeft;
     uint16_t nWorkScore;
-    uint256 wtxid;
+    uint256 hashWTPrime;
 
-    std::string ToString() const;
     bool IsNull() const;
     uint256 GetHash(void) const;
-    bool operator==(const SidechainWTJoinState& a) const;
+    bool operator==(const SidechainWTPrimeState& a) const;
+    std::string ToString() const;
 
     // For hash calculation
     ADD_SERIALIZE_METHODS
@@ -72,19 +84,19 @@ struct SidechainWTJoinState {
         READWRITE(nSidechain);
         READWRITE(nBlocksLeft);
         READWRITE(nWorkScore);
-        READWRITE(wtxid);
+        READWRITE(hashWTPrime);
     }
 };
 
 struct SCDBIndex {
-    std::array<SidechainWTJoinState, SIDECHAIN_MAX_WT> members;
+    std::array<SidechainWTPrimeState, SIDECHAIN_MAX_WT> members;
     bool IsPopulated() const;
     bool IsFull() const;
-    bool InsertMember(const SidechainWTJoinState& member);
+    bool InsertMember(const SidechainWTPrimeState& member);
     void ClearMembers();
     unsigned int CountPopulatedMembers() const;
     bool Contains(uint256 hashWT) const;
-    bool GetMember(uint256 hashWT, SidechainWTJoinState& wt) const;
+    bool GetMember(uint256 hashWT, SidechainWTPrimeState& wt) const;
 };
 
 // TODO c++11 std::array

--- a/src/test/bmm_tests.cpp
+++ b/src/test/bmm_tests.cpp
@@ -1,0 +1,183 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "chainparams.h"
+#include "consensus/validation.h"
+#include "core_io.h"
+#include "miner.h"
+#include "random.h"
+#include "script/sigcache.h"
+#include "sidechain.h"
+#include "sidechaindb.h"
+#include "uint256.h"
+#include "utilstrencodings.h"
+#include "validation.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(bmm_tests, TestChain100Setup)
+
+/* TODO refactor along with DAG PR
+
+BOOST_AUTO_TEST_CASE(bmm_checkCriticalHashValid)
+{
+    // Check that valid critical hash is added to ratchet
+    SidechainDB scdb;
+
+    // Create h* bribe script
+    uint256 hashCritical = GetRandHash();
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << CScriptNum::serialize(1) << ToByteVector(hashCritical);
+
+    // Create dummy coinbase with h*
+    CMutableTransaction mtx;
+    mtx.nVersion = 1;
+    mtx.vin.resize(1);
+    mtx.vout.resize(1);
+    mtx.vin[0].scriptSig = CScript() << 486604799;
+    mtx.vout.push_back(CTxOut(50 * CENT, scriptPubKey));
+
+    // Update SCDB so that h* is processed
+    uint256 hashBlock = GetRandHash();
+    std::string strError = "";
+    scdb.Update(0, hashBlock, mtx.vout, strError);
+
+    // Get linking data
+    std::multimap<uint256, int> mapLD = scdb.GetLinkingData();
+
+    // Verify that h* was added
+    std::multimap<uint256, int>::const_iterator it = mapLD.find(hashCritical);
+    BOOST_CHECK(it != mapLD.end());
+
+}
+
+BOOST_AUTO_TEST_CASE(bmm_checkCriticalHashInvalid)
+{
+    // Make sure that a invalid h* with a valid block number will
+    // be rejected.
+    SidechainDB scdb;
+
+    // Create h* bribe script
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << CScriptNum::serialize(21000) << 0x426974636F696E;
+
+    // Create dummy coinbase with h* bribe
+    CMutableTransaction mtx;
+    mtx.nVersion = 1;
+    mtx.vin.resize(1);
+    mtx.vout.resize(1);
+    mtx.vin[0].scriptSig = CScript() << 486604799;
+    mtx.vout.push_back(CTxOut(50 * CENT, scriptPubKey));
+
+    // Update SCDB so that h* is processed
+    uint256 hashBlock = GetRandHash();
+    std::string strError = "";
+    scdb.Update(0, hashBlock, mtx.vout, strError);
+
+    // Verify that h* was rejected, linking data should be empty
+    std::multimap<uint256, int> mapLD = scdb.GetLinkingData();
+    BOOST_CHECK(mapLD.empty());
+}
+
+BOOST_AUTO_TEST_CASE(bmm_checkBlockNumberValid)
+{
+    // Make sure that a valid h* with a valid block number
+    // will be accepted.
+    SidechainDB scdb;
+
+    // We have to add the first h* to the ratchet so that
+    // there is something to compare with.
+
+    // Create h* bribe script
+    uint256 hashCritical = GetRandHash();
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << CScriptNum::serialize(1) << ToByteVector(hashCritical);
+
+    // Create dummy coinbase with h* in output
+    CMutableTransaction mtx;
+    mtx.nVersion = 1;
+    mtx.vin.resize(1);
+    mtx.vout.resize(1);
+    mtx.vin[0].scriptSig = CScript() << 486604799;
+    mtx.vout.push_back(CTxOut(50 * CENT, scriptPubKey));
+
+    // Update SCDB so that first h* is processed
+    uint256 hashBlock = GetRandHash();
+    std::string strError = "";
+    scdb.Update(0, hashBlock, mtx.vout, strError);
+
+    // Now we add a second h* with a valid block number
+
+    // Create second h* bribe script
+    uint256 hashCritical2 = GetRandHash();
+    CScript scriptPubKey2;
+    scriptPubKey2 << OP_RETURN << CScriptNum::serialize(2) << ToByteVector(hashCritical2);
+
+    // Update SCDB so that second h* is processed
+    mtx.vout[0] = CTxOut(50 * CENT, scriptPubKey2);
+    scdb.Update(0, hashBlock, mtx.vout, strError);
+
+    // Get linking data
+    std::multimap<uint256, int> mapLD = scdb.GetLinkingData();
+
+    // Verify that h* was added
+    std::multimap<uint256, int>::const_iterator it = mapLD.find(hashCritical2);
+    BOOST_CHECK(it != mapLD.end());
+}
+
+BOOST_AUTO_TEST_CASE(bmm_checkBlockNumberInvalid)
+{
+    // Try to add a valid h* with an invalid block number
+    // and make sure it is skipped.
+    SidechainDB scdb;
+
+    // We have to add the first h* to the ratchet so that
+    // there is something to compare with.
+
+    // Create first h* bribe script
+    CScript scriptPubKey;
+    scriptPubKey << OP_RETURN << CScriptNum::serialize(10) << ToByteVector(GetRandHash());
+
+    // Create dummy coinbase with h* in output
+    CMutableTransaction mtx;
+    mtx.nVersion = 1;
+    mtx.vin.resize(1);
+    mtx.vout.resize(1);
+    mtx.vin[0].scriptSig = CScript() << 486604799;
+    mtx.vout.push_back(CTxOut(50 * CENT, scriptPubKey));
+
+    // Update SCDB so that first h* is processed
+    std::string strError = "";
+    scdb.Update(0, GetRandHash(), mtx.vout, strError);
+
+    // Now we add a second h* with an invalid block number
+
+    // Create second h* bribe script
+    uint256 hashCritical2 = GetRandHash();
+    CScript scriptPubKey2;
+    scriptPubKey2 << OP_RETURN << CScriptNum::serialize(100) << ToByteVector(hashCritical2);
+
+    // Update SCDB so that second h* is processed
+    CMutableTransaction mtx1;
+    mtx1.nVersion = 1;
+    mtx1.vin.resize(1);
+    mtx1.vout.resize(1);
+    mtx1.vin[0].scriptSig = CScript() << 486604899;
+    mtx1.vout.push_back(CTxOut(50 * CENT, scriptPubKey2));
+
+    scdb.Update(1, GetRandHash(), mtx1.vout, strError);
+
+    // Get linking data
+    std::multimap<uint256, int> mapLD = scdb.GetLinkingData();
+
+    // Verify that h* was rejected
+    std::multimap<uint256, int>::const_iterator it = mapLD.find(hashCritical2);
+    BOOST_CHECK(it == mapLD.end());
+}
+
+*/
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
* Remove old WT^ tracking code

* Add SCDB hashMerkleRoot based updates & WT^ update network messages (tested
  via RPC). When a new block is added to the tip, we look for a SCDB
  hashMerkleRoot commit and verify the WT^ update messages we have
  recieved over the network to try and update our local WT^ workscores.

* Add receivesidechainwtprimeupdate RPC function to test WT^ update
  network messages

* Remove old unit tests, replaced with updated tests.

* Refactoring:
  - wtxid -> hashWTPrime
  - wtJoin -> wtPrime

* Cleanup:
  - Fix order of functions
  - Rename some functions for clarity

* WT^ creation performance improvement & rename for clarity:
(CTransaction BlockAssembler::CreateWTPrimePayout(uint8_t nSidechain))