### PR TITLE
small fix to sidechaindb_isolated unit tests

### DIFF
--- a/src/test/sidechaindb_tests.cpp
+++ b/src/test/sidechaindb_tests.cpp
@@ -28,8 +28,8 @@ BOOST_AUTO_TEST_CASE(sidechaindb_isolated)
     uint256 hashWTWimble = GetRandHash();
 
     const Sidechain& test = ValidSidechains[SIDECHAIN_TEST];
-    const Sidechain& hivemind = ValidSidechains[SIDECHAIN_TEST];
-    const Sidechain& wimble = ValidSidechains[SIDECHAIN_TEST];
+    const Sidechain& hivemind = ValidSidechains[SIDECHAIN_HIVEMIND];
+    const Sidechain& wimble = ValidSidechains[SIDECHAIN_WIMBLE];
 
     // SIDECHAIN_TEST
     SidechainWTPrimeState wtTest;


### PR DESCRIPTION
The unit tests for sidechain seem to improperly use the SIDECHAIN_TEST enum for the sidechaindb_isolated tests CheckWorkScore tests. This PR updates to the appropriate enum.