### PR TITLE
Refactor: make use of new ValidSidechains container

### DIFF
--- a/src/sidechain.cpp
+++ b/src/sidechain.cpp
@@ -185,7 +185,7 @@ bool SCDBIndex::GetMember(uint256 hashWT, SidechainWTPrimeState& wt) const
 
 bool IsSidechainNumberValid(uint8_t nSidechain)
 {
-    if (!(nSidechain < ARRAYLEN(ValidSidechains)))
+    if (!(nSidechain < ValidSidechains.size()))
         return false;
 
     // Check that number corresponds to a valid sidechain

--- a/src/sidechaindb.cpp
+++ b/src/sidechaindb.cpp
@@ -14,7 +14,7 @@
 
 SidechainDB::SidechainDB()
 {
-    size_t nSidechains = ARRAYLEN(ValidSidechains);
+    size_t nSidechains = ValidSidechains.size();
     SCDB.resize(nSidechains );
     ratchet.resize(nSidechains);
 }
@@ -240,7 +240,7 @@ std::vector<CTransaction> SidechainDB::GetWTPrimeCache() const
 bool SidechainDB::HasState() const
 {
     // Make sure that SCDB is actually initialized
-    if (SCDB.size() != ARRAYLEN(ValidSidechains))
+    if (SCDB.size() != ValidSidechains.size())
         return false;
 
     // Check if any SCDBIndex(s) are populated


### PR DESCRIPTION
Now that ValidSidechains is an std::array we don't need to use ARRAYLEN