### PR TITLE
Change deposit button to black text, update margin and helper text

### DIFF
--- a/src/qt/forms/sidechaindepositdialog.ui
+++ b/src/qt/forms/sidechaindepositdialog.ui
@@ -22,6 +22,9 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="styleSheet">
+      <string>color: black;</string>
+     </property>
      <property name="text">
       <string>Deposit</string>
      </property>
@@ -66,7 +69,10 @@
      <item>
       <widget class="QValidatedLineEdit" name="payTo">
        <property name="toolTip">
-        <string>The Bitcoin address to send the payment to</string>
+        <string>The Sidechain Address to send the payment</string>
+       </property>
+        <property name="styleSheet">
+         <string>margin-right: 5px;</string>
        </property>
        <property name="text">
         <string/>
@@ -130,12 +136,12 @@
   <customwidget>
    <class>QValidatedLineEdit</class>
    <extends>QLineEdit</extends>
-   <header>qvalidatedlineedit.h</header>
+   <header>qt/qvalidatedlineedit.h</header>
   </customwidget>
   <customwidget>
    <class>BitcoinAmountField</class>
    <extends>QLineEdit</extends>
-   <header>bitcoinamountfield.h</header>
+   <header>qt/bitcoinamountfield.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/qt/forms/sidechaindepositdialog.ui
+++ b/src/qt/forms/sidechaindepositdialog.ui
@@ -22,9 +22,6 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="styleSheet">
-      <string>color: black;</string>
-     </property>
      <property name="text">
       <string>Deposit</string>
      </property>


### PR DESCRIPTION
I agree with https://github.com/drivechain-project/bitcoin/issues/64 - the main thing that was bothering me was the white text string on the button was illegible. This updates that and fixes the margin and tweaks the helper text.
This file was from the "post-rebase" branch I was working on, so it shouldn't actually be merged until after (or as part of) the rebase