### PR TITLE
UI / RPC, validation, miner updates for test guide

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -82,6 +82,7 @@ bool CTransaction::GetBWTHash(uint256& hashRet) const
         return false;
 
     // This is the format the sidechain must use for vin[0]
+    mtx.vin.clear();
     mtx.vin.resize(1);
     mtx.vin[0].scriptSig = CScript() << OP_0;
 

--- a/src/qt/sidechaindepositdialog.cpp
+++ b/src/qt/sidechaindepositdialog.cpp
@@ -112,7 +112,9 @@ void SidechainDepositDialog::on_pushButtonDeposit_clicked()
 
     // Successful deposit message box
     messageBox.setWindowTitle("Deposit transaction created!");
-    QString result = "txid: " + QString::fromStdString(tx->GetHash().ToString());
+    QString result = "Deposited to " + QString::fromStdString(GetSidechainName(nSidechain));
+    result += " Sidechain.\n";
+    result += "txid: " + QString::fromStdString(tx->GetHash().ToString());
     result += "\n";
     result += "Amount deposited: ";
     result += BitcoinUnits::formatWithUnit(BitcoinUnit::BTC, nValue, false, BitcoinUnits::separatorAlways);

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -912,14 +912,15 @@ UniValue receivewtprime(const JSONRPCRequest& request)
      );
 
     // Is nSidechain valid?
-    uint8_t nSidechain = request.params[0].get_int();
+    int nSidechain = request.params[0].get_int();
     if (!IsSidechainNumberValid(nSidechain))
-        throw std::runtime_error("Invalid sidechain number");
+        throw std::runtime_error("Invalid sidechain number!");
 
     // Create CTransaction from hex
     CMutableTransaction mtx;
     std::string hex = request.params[1].get_str();
-    DecodeHexTx(mtx, hex);
+    if (!DecodeHexTx(mtx, hex))
+        throw std::runtime_error("Invalid transaction hex!");
 
     CTransaction wtPrime(mtx);
 

--- a/src/sidechain.h
+++ b/src/sidechain.h
@@ -15,6 +15,8 @@ static const int SIDECHAIN_MAX_WT = 3; // TODO remove
 static const size_t VALID_SIDECHAINS_COUNT = 5;
 static const int SIDECHAIN_VERIFICATION_PERIOD = 26298;
 static const int SIDECHAIN_MIN_WORKSCORE = 13140;
+static const int SIDECHAIN_TEST_MIN_WORKSCORE = 6; // TODO remove
+static const int SIDECHAIN_TEST_VERIFICATION_PERIOD = 35; // TODO remove
 
 enum SidechainNumber {
     SIDECHAIN_TEST = 0,

--- a/src/sidechaindb.h
+++ b/src/sidechaindb.h
@@ -69,7 +69,7 @@ public:
     /** Get status of nSidechain's WT^(s) (public for unit tests) */
     std::vector<SidechainWTPrimeState> GetState(uint8_t nSidechain) const;
 
-    /** Return the cached WT^ transaction */
+    /** Return the cached WT^ transaction(s) */
     std::vector<CTransaction> GetWTPrimeCache() const;
 
     /** Is there anything being tracked by the SCDB? */
@@ -103,6 +103,15 @@ public:
      *  SCDB matches that of the new block. Return false if no match found.
      */
     bool UpdateSCDBMatchMT(int nHeight, const uint256& hashMerkleRoot);
+
+    /** Get state with upvotes applied to all WT^(s) */
+    std::vector<SidechainWTPrimeState> GetDownvotes() const;
+
+    /** Get state with abstain votes applied to all WT^(s) */
+    std::vector<SidechainWTPrimeState> GetAbstainVotes() const;
+
+    /** Get state with downvotes applied to all WT^(s) */
+    std::vector<SidechainWTPrimeState> GetUpvotes() const;
 
 private:
     /** Sidechain "database" tracks verification status of WT^(s) */

--- a/src/test/sidechaindb_tests.cpp
+++ b/src/test/sidechaindb_tests.cpp
@@ -187,7 +187,6 @@ BOOST_AUTO_TEST_CASE(sidechaindb_MT_single)
 
     scdb.AddSidechainNetworkUpdatePackage(updatePackage);
 
-
     BOOST_CHECK(scdb.UpdateSCDBMatchMT(2, scdbCopy.GetSCDBHash()));
 
     // Reset SCDB after testing


### PR DESCRIPTION
* Let SIDECHAIN_TEST have 35 block verification period for testing WT^(s)
* Reduced work score requirement for SIDECHAIN_TEST (6)
* Fix bug in WT^ blinding function
* Updated sidechain deopsit dialog
* RPC updates
* Add GetUpvotes GetDownvotes GetAbstainVotes to SidechainDB which will
return all of the current WT^(s) being tracked, with the respective
votes applied.