### PR TITLE
Support Qt-5.15.2

### DIFF
--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -6,6 +6,7 @@
 #include <qt/clientmodel.h>
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QColor>
 #include <QTimer>
 


### PR DESCRIPTION
Mainchain release uses Qt 5.7.1, though Qt 5.15.2 seems to break compatibility because QPainterPath is not picked up. I'm assuming this'll work for Qt 5.7.1. 